### PR TITLE
Revert "Update pyo3 requirement from 0.18.0 to 0.19.0"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 pythonize = "0.18"
 
 [dependencies.pyo3]
-version = "0.19.0"
+version = "0.18.0"
 features = ["extension-module"]
 
 [dependencies.sqlparser]


### PR DESCRIPTION
Reverts mabel-dev/opteryx#1062